### PR TITLE
refactor: Improve handling of errors and promises

### DIFF
--- a/src/app/oauth/index.ts
+++ b/src/app/oauth/index.ts
@@ -1,8 +1,0 @@
-import { Hono } from "hono"
-
-import { sheets } from "./sheets"
-import { signin } from "./signin"
-
-const app = new Hono().route("/signin", signin).route("/sheets", sheets)
-
-export { app as oauth }

--- a/src/app/oauth/index.tsx
+++ b/src/app/oauth/index.tsx
@@ -1,0 +1,22 @@
+import { Hono } from "hono"
+import { HTTPException } from "hono/http-exception"
+
+import { sheets } from "./sheets"
+import { signin } from "./signin"
+
+import { ErrorAlert } from "@/components/ErrorAlert"
+
+const app = new Hono()
+    .route("/signin", signin)
+    .route("/sheets", sheets)
+    .onError((error, c) => {
+        if (error instanceof HTTPException && error.res) return error.res
+        const { status, message } =
+            error instanceof HTTPException
+                ? error
+                : ({ status: 500, message: "Internal Server Error" } as const)
+        c.status(status)
+        return c.render(<ErrorAlert>{message}</ErrorAlert>)
+    })
+
+export { app as oauth }

--- a/src/app/oauth/sheets/callback/index.tsx
+++ b/src/app/oauth/sheets/callback/index.tsx
@@ -1,4 +1,3 @@
-import type { WebhooksAPI } from "@discordjs/core/http-only"
 import { reactRenderer } from "@hono/react-renderer"
 import { vValidator } from "@hono/valibot-validator"
 import type { RESTPatchAPIWebhookWithTokenMessageJSONBody } from "discord-api-types/v10"
@@ -16,7 +15,6 @@ import { ErrorAlert } from "@/components/ErrorAlert"
 import { DrivePicker } from "@/components/islands/drive-picker/server"
 import { createLayout } from "@/components/layout"
 import { guildConfigInit } from "@/lib/discord/constants"
-import { type ErrorContext, reportErrorWithContext } from "@/lib/discord/utils"
 import type { Env } from "@/lib/schema/env"
 import { $GuildConfig, $SessionId, $SheetsOAuthSession } from "@/lib/schema/kvNamespaces"
 import { oAuthCallbackQueryParams } from "@/lib/schema/oauth"
@@ -74,27 +72,20 @@ const app = new Hono<Env>().get(
             return c.render(<ErrorAlert title="Unauthorized">無効なリクエストです。</ErrorAlert>)
         }
 
-        const errorContext = {
-            guildId: session.guildId,
-        } as const satisfies ErrorContext
-        const originalInteractions = [
-            c.env.DISCORD_APPLICATION_ID,
-            session.interactionToken,
-            "@original",
-        ] satisfies Parameters<WebhooksAPI["getMessage"]>
-        const editOriginal = async (
-            body: RESTPatchAPIWebhookWithTokenMessageJSONBody,
-        ): Promise<void> => {
-            await c.var.discord.webhooks
-                .editMessage(...originalInteractions, body)
-                .catch(async (e: unknown) => {
-                    if (e instanceof Error) await reportErrorWithContext(e, errorContext, c.env)
-                })
+        const editOriginal = (body: RESTPatchAPIWebhookWithTokenMessageJSONBody) => {
+            c.executionCtx.waitUntil(
+                c.var.discord.webhooks.editMessage(
+                    c.env.DISCORD_APPLICATION_ID,
+                    session.interactionToken,
+                    "@original",
+                    body,
+                ),
+            )
         }
         const rawGuildConfig = await guildConfigRecord.get(session.guildId, "json").catch(id)
         const guildConfigParseResult = v.safeParse($GuildConfig, rawGuildConfig ?? guildConfigInit)
         if (!guildConfigParseResult.success) {
-            await editOriginal({
+            editOriginal({
                 content: ":x: サーバーの設定データが破損しています。",
                 components: [],
             })
@@ -107,7 +98,7 @@ const app = new Hono<Env>().get(
         }
         const guildConfig = guildConfigParseResult.output
         if (query.error !== undefined) {
-            await editOriginal({
+            editOriginal({
                 content: OAUTH_FAILED_MESSAGE,
                 components: [],
             })
@@ -128,7 +119,7 @@ const app = new Hono<Env>().get(
         }
         const { tokens } = getTokenResponse
         if (!(tokens.access_token && tokens.expiry_date && tokens.refresh_token)) {
-            await editOriginal({
+            editOriginal({
                 content: OAUTH_FAILED_MESSAGE,
                 components: [],
             })
@@ -142,9 +133,13 @@ const app = new Hono<Env>().get(
             accessToken: tokens.access_token,
             accessTokenExpiry: tokens.expiry_date,
         })
-        await guildConfigRecord.put(session.guildId, JSON.stringify(guildConfig))
         session.accessToken = tokens.access_token
-        await sessionRecord.put(sessionId, JSON.stringify(session))
+        c.executionCtx.waitUntil(
+            Promise.all([
+                guildConfigRecord.put(session.guildId, JSON.stringify(guildConfig)),
+                sessionRecord.put(sessionId, JSON.stringify(session)),
+            ]),
+        )
         return c.render(
             <DrivePicker
                 formAction="./complete"

--- a/src/app/oauth/sheets/callback/index.tsx
+++ b/src/app/oauth/sheets/callback/index.tsx
@@ -12,7 +12,6 @@ import { appSteps } from "../steps"
 
 import type { AppType } from "@/app"
 import { App } from "@/components/App"
-import { ErrorAlert } from "@/components/ErrorAlert"
 import { DrivePicker } from "@/components/islands/drive-picker/server"
 import { createLayout } from "@/components/layout"
 import { guildConfigInit } from "@/lib/discord/constants"

--- a/src/app/oauth/sheets/complete/index.tsx
+++ b/src/app/oauth/sheets/complete/index.tsx
@@ -67,7 +67,7 @@ const app = new Hono<Env>().post(
         const { folderId } = c.req.valid("form")
         const sessionId = c.req.valid("cookie").sid
         const rawSession = await sessionRecord.get(sessionId, "json").catch(orNull)
-        await sessionRecord.delete(sessionId)
+        c.executionCtx.waitUntil(sessionRecord.delete(sessionId))
         const sessionParseResult = v.safeParse($SheetsOAuthSession, rawSession)
         if (!sessionParseResult.success) {
             c.status(400)
@@ -177,7 +177,9 @@ const app = new Hono<Env>().post(
             )
         }
         guildConfig._sheet.spreadsheetId = spreadsheetId
-        await guildConfigRecord.put(session.guildId, JSON.stringify(guildConfig))
+        c.executionCtx.waitUntil(
+            guildConfigRecord.put(session.guildId, JSON.stringify(guildConfig)),
+        )
         return c.render(
             <>
                 <SuccessAlert>スプレッドシートが作成され、初期化されました。</SuccessAlert>

--- a/src/app/oauth/sheets/complete/index.tsx
+++ b/src/app/oauth/sheets/complete/index.tsx
@@ -12,7 +12,6 @@ import * as v from "valibot"
 import { appSteps } from "../steps"
 
 import { App } from "@/components/App"
-import { ErrorAlert } from "@/components/ErrorAlert"
 import { NotchedOutline } from "@/components/NotchedOutline"
 import { SuccessAlert } from "@/components/SuccessAlert"
 import { createLayout } from "@/components/layout"

--- a/src/app/oauth/sheets/complete/index.tsx
+++ b/src/app/oauth/sheets/complete/index.tsx
@@ -6,6 +6,7 @@ import { drive_v3 } from "googleapis/build/src/apis/drive/v3"
 import { sheets_v4 } from "googleapis/build/src/apis/sheets/v4"
 import { Hono } from "hono"
 import { deleteCookie } from "hono/cookie"
+import { HTTPException } from "hono/http-exception"
 import * as v from "valibot"
 
 import { appSteps } from "../steps"
@@ -16,7 +17,7 @@ import { NotchedOutline } from "@/components/NotchedOutline"
 import { SuccessAlert } from "@/components/SuccessAlert"
 import { createLayout } from "@/components/layout"
 import { guildConfigInit } from "@/lib/discord/constants"
-import { type ErrorContext, reportErrorWithContext } from "@/lib/discord/utils"
+import { getDiscordAPIErrorMessage } from "@/lib/discord/utils"
 import type { Env } from "@/lib/schema/env"
 import { $GuildConfig, $SessionId, $SheetsOAuthSession } from "@/lib/schema/kvNamespaces"
 import type { AppPropertiesV1 } from "@/lib/schema/spreadsheet"
@@ -42,9 +43,11 @@ const app = new Hono<Env>().post(
         v.object({
             folderId: v.string(),
         }),
-        (result, c) => {
+        (result) => {
             if (!result.success) {
-                return c.render(<ErrorAlert>フォームの入力内容が正しくありません。</ErrorAlert>)
+                throw new HTTPException(400, {
+                    message: "フォームの入力内容が正しくありません。",
+                })
             }
         },
     ),
@@ -53,10 +56,9 @@ const app = new Hono<Env>().post(
         v.object({
             sid: $SessionId,
         }),
-        (result, c) => {
+        (result) => {
             if (!result.success) {
-                c.status(400)
-                return c.render(<ErrorAlert title="Bad Request">セッションが無効です。</ErrorAlert>)
+                throw new HTTPException(400, { message: "セッションが無効です。" })
             }
         },
     ),
@@ -70,46 +72,28 @@ const app = new Hono<Env>().post(
         c.executionCtx.waitUntil(sessionRecord.delete(sessionId))
         const sessionParseResult = v.safeParse($SheetsOAuthSession, rawSession)
         if (!sessionParseResult.success) {
-            c.status(400)
             deleteCookie(c, "sid")
-            return c.render(<ErrorAlert title="Bad Request">セッションが無効です。</ErrorAlert>)
+            throw new HTTPException(400, { message: "セッションが無効です。" })
         }
         const session = sessionParseResult.output
         const rawGuildConfig = await guildConfigRecord.get(session.guildId, "json").catch(id)
         const guildConfigParseResult = v.safeParse($GuildConfig, rawGuildConfig ?? guildConfigInit)
         if (!guildConfigParseResult.success) {
-            c.status(500)
-            return c.render(
-                <ErrorAlert title="Internal Server Error">
-                    サーバーの設定データが破損しています。
-                </ErrorAlert>,
-            )
+            throw new HTTPException(500, { message: "サーバーの設定データが破損しています。" })
         }
         const guildConfig = guildConfigParseResult.output
         if (!guildConfig._sheet) {
-            c.status(400)
-            return c.render(
-                <ErrorAlert title="Internal Server Error">セッションが不正です。</ErrorAlert>,
-            )
+            throw new HTTPException(400, { message: "セッションが不正です。" })
         }
-        const errorContext = {
-            guildId: session.guildId,
-        } as const satisfies ErrorContext
-
         const guildPreview = await c.var.discord.guilds
             .getPreview(session.guildId)
-            .catch(id<unknown, Error>)
+            .catch((e: unknown) => {
+                throw new HTTPException(500, {
+                    message: `スプレッドシートを指定されたフォルダに作成することができませんでした。\n${getDiscordAPIErrorMessage(e)}`,
+                    cause: e,
+                })
+            })
 
-        if (guildPreview instanceof Error) {
-            c.status(500)
-            await reportErrorWithContext(guildPreview, errorContext, c.env)
-            return c.render(
-                <ErrorAlert title="Internal Server Error">
-                    スプレッドシートを指定されたフォルダに作成することができませんでした。
-                    {guildPreview.message}
-                </ErrorAlert>,
-            )
-        }
         const oAuth2Client = new OAuth2Client({
             credentials: {
                 access_token: session.accessToken,
@@ -132,50 +116,35 @@ const app = new Hono<Env>().post(
                 fields: "id",
                 supportsAllDrives: true,
             })
-            .catch(id<unknown, Error>)
-
-        if (spreadsheetCreateResponse instanceof Error) {
-            c.status(500)
-            await reportErrorWithContext(spreadsheetCreateResponse, errorContext, c.env)
-            return c.render(
-                <ErrorAlert title="Internal Server Error">
-                    スプレッドシートを指定されたフォルダに作成することができませんでした。
-                    {spreadsheetCreateResponse.message}
-                </ErrorAlert>,
-            )
-        }
+            .catch((e: unknown) => {
+                throw new HTTPException(500, {
+                    message:
+                        "スプレッドシートを指定されたフォルダに作成することができませんでした。",
+                    cause: e,
+                })
+            })
         const spreadsheetId = spreadsheetCreateResponse.data.id
         if (!spreadsheetId) {
-            c.status(500)
-            await reportErrorWithContext(
-                new Error("Could not get the ID of the created file."),
-                errorContext,
-                c.env,
-            )
-            return c.render(
-                <ErrorAlert title="Internal Server Error">
-                    作成したスプレッドシートの情報を取得することができませんでした。
-                </ErrorAlert>,
-            )
+            throw new HTTPException(500, {
+                message: "作成したスプレッドシートの情報を取得することができませんでした。",
+            })
         }
 
-        const sheetUpdateResponse = await sheets.spreadsheets
-            .batchUpdate({
-                spreadsheetId,
-                requestBody: {
-                    requests: spreadsheetInit,
-                },
-            })
-            .catch(id<unknown, Error>)
-        if (sheetUpdateResponse instanceof Error) {
-            c.status(500)
-            await reportErrorWithContext(sheetUpdateResponse, errorContext, c.env)
-            return c.render(
-                <ErrorAlert title="Internal Server Error">
-                    作成したスプレッドシートに書き込むことができませんでした。
-                </ErrorAlert>,
-            )
-        }
+        c.executionCtx.waitUntil(
+            sheets.spreadsheets
+                .batchUpdate({
+                    spreadsheetId,
+                    requestBody: {
+                        requests: spreadsheetInit,
+                    },
+                })
+                .catch((e: unknown) => {
+                    throw new HTTPException(500, {
+                        message: "作成したスプレッドシートに書き込むことができませんでした。",
+                        cause: e,
+                    })
+                }),
+        )
         guildConfig._sheet.spreadsheetId = spreadsheetId
         c.executionCtx.waitUntil(
             guildConfigRecord.put(session.guildId, JSON.stringify(guildConfig)),

--- a/src/app/oauth/sheets/index.tsx
+++ b/src/app/oauth/sheets/index.tsx
@@ -13,7 +13,6 @@ import { appSteps } from "./steps"
 
 import type { AppType } from "@/app"
 import { App } from "@/components/App"
-import { ErrorAlert } from "@/components/ErrorAlert"
 import { createLayout } from "@/components/layout"
 import type { Env } from "@/lib/schema/env"
 import { $RequestToken, $SheetsOAuthSession, type AuthNRequest } from "@/lib/schema/kvNamespaces"

--- a/src/app/oauth/signin/callback/index.tsx
+++ b/src/app/oauth/signin/callback/index.tsx
@@ -14,7 +14,6 @@ import { appSteps } from "../steps"
 
 import type { AppType } from "@/app"
 import { App } from "@/components/App"
-import { ErrorAlert } from "@/components/ErrorAlert"
 import { SuccessAlert } from "@/components/SuccessAlert"
 import { createLayout } from "@/components/layout"
 import { guildConfigInit } from "@/lib/discord/constants"

--- a/src/app/oauth/signin/index.tsx
+++ b/src/app/oauth/signin/index.tsx
@@ -103,9 +103,7 @@ const app = new Hono<Env>()
                 c.status(400)
                 return c.render(
                     <>
-                        <ErrorAlert title="Bad Request">
-                            フォームの入力内容が正しくありません。
-                        </ErrorAlert>
+                        <ErrorAlert>フォームの入力内容が正しくありません。</ErrorAlert>
                         <ProfileForm />
                     </>,
                 )

--- a/src/app/oauth/signin/index.tsx
+++ b/src/app/oauth/signin/index.tsx
@@ -5,6 +5,7 @@ import { OAuth2Client } from "google-auth-library"
 import { Hono } from "hono"
 import { hc } from "hono/client"
 import { getCookie, setCookie } from "hono/cookie"
+import { HTTPException } from "hono/http-exception"
 import * as v from "valibot"
 
 import { callback } from "./callback"
@@ -44,14 +45,11 @@ const app = new Hono<Env>()
             v.object({
                 token: $RequestToken,
             }),
-            (result, c) => {
+            (result) => {
                 if (!result.success) {
-                    c.status(400)
-                    return c.render(
-                        <ErrorAlert title="Bad Request">
-                            トークンが指定されませんでした。
-                        </ErrorAlert>,
-                    )
+                    throw new HTTPException(400, {
+                        message: "トークンが指定されませんでした。",
+                    })
                 }
             },
         ),
@@ -72,8 +70,9 @@ const app = new Hono<Env>()
                 } else return getCookie(c, "sid")
             })()
             if (!sessionId) {
-                c.status(400)
-                return c.render(<ErrorAlert title="Bad Request">トークンが無効です。</ErrorAlert>)
+                throw new HTTPException(400, {
+                    message: "トークンが無効です。",
+                })
             }
             return c.render(<ProfileForm />)
         },
@@ -85,11 +84,11 @@ const app = new Hono<Env>()
             v.object({
                 sid: v.string(),
             }),
-            (result, c) => {
+            (result) => {
                 if (!result.success) {
-                    return c.render(
-                        <ErrorAlert title="Bad Request">セッションが無効です。</ErrorAlert>,
-                    )
+                    throw new HTTPException(400, {
+                        message: "セッションが無効です。",
+                    })
                 }
             },
         ),
@@ -117,13 +116,15 @@ const app = new Hono<Env>()
             const rawSession = await sessionRecord.get(sessionId, "json").catch(orNull)
             const sessionParseResult = v.safeParse($Session, rawSession)
             if (!sessionParseResult.success) {
-                c.status(400)
-                return c.render(<ErrorAlert title="Bad Request">セッションが無効です。</ErrorAlert>)
+                throw new HTTPException(400, {
+                    message: "セッションが無効です。",
+                })
             }
             const session = sessionParseResult.output
             if (session.state || session.nonce) {
-                c.status(400)
-                return c.render(<ErrorAlert title="Bad Request">セッションが不正です。</ErrorAlert>)
+                throw new HTTPException(400, {
+                    message: "セッションが不正です。",
+                })
             }
             const honoClient = hc<AppType>(c.env.ORIGIN)
             const redirectUri = honoClient.oauth.signin.callback.$url()

--- a/src/components/islands/profile-form/core.tsx
+++ b/src/components/islands/profile-form/core.tsx
@@ -82,13 +82,11 @@ export const Core = () => {
 
     // CheckboxElementのonChangeでトリガーするとRHFとReactが競合して4, 5回再レンダリングされてしまう上に、古いデータを参照することがある
     useEffect(() => {
-        void (async () => {
-            await trigger(
-                objectPaths(dirtyFields, {
-                    fullPathOnly: true,
-                }),
-            )
-        })()
+        void trigger(
+            objectPaths(dirtyFields, {
+                fullPathOnly: true,
+            }),
+        )
         // eslint-disable-next-line react-hooks/exhaustive-deps -- dirtyFieldsは更新されると自動で再トリガーされる / triggerは更新を監視する対象ではない
     }, [isStudent])
 

--- a/src/lib/discord/commands/initCommand.ts
+++ b/src/lib/discord/commands/initCommand.ts
@@ -177,7 +177,7 @@ export const handler: CommandHandler<Env> = async (c) => {
                 }
             })
     }
-    await guildConfigRecord.put(guildId, JSON.stringify(guildConfig))
+    c.executionCtx.waitUntil(guildConfigRecord.put(guildId, JSON.stringify(guildConfig)))
 
     if (errors.length) return c.res(errors.join("\n"))
     return c.resModal(Modals.init.modal)

--- a/src/lib/utils/misc.ts
+++ b/src/lib/utils/misc.ts
@@ -3,13 +3,6 @@ import type {
     ContentlessStatusCode,
     StatusCode,
 } from "hono/utils/http-status"
-import { Buffer } from "node:buffer"
-
-export const generateDataUrlFromHttpUrl = async (url: URL | string) => {
-    const res = await fetch(url)
-    const blob = await res.blob()
-    return `data:${blob.type};base64,${Buffer.from(await blob.arrayBuffer()).toString("base64")}`
-}
 
 export const contentlessStatusCodes: StatusCode[] = [
     101, 204, 205, 304,


### PR DESCRIPTION
- Use `HTTPException` to integrate error responses
- Use `c.executionCtx.waitUntil` for promises that don't need await